### PR TITLE
docs(load-data): isolate ray-curator text load-data docs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/apidocs/
 
 # PyBuilder
 .pybuilder/

--- a/docs/curate-text/load-data/arxiv.md
+++ b/docs/curate-text/load-data/arxiv.md
@@ -1,0 +1,166 @@
+---
+description: "Download and extract text from arXiv using ray-curator's pipeline framework"
+categories: ["how-to-guides"]
+tags: ["arxiv", "academic-papers", "latex", "data-loading", "scientific-data", "ray-curator"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "intermediate"
+content_type: "how-to"
+modality: "text-only"
+---
+
+# ArXiv
+
+(text-load-data-arxiv)=
+
+Download and extract text from ArXiv LaTeX source bundles using ray-curator's pipeline framework.
+
+ArXiv hosts millions of scholarly papers, typically distributed as LaTeX source inside `.tar` archives under the `s3://arxiv/src/` requester-pays bucket.
+
+## How it Works
+
+The ArXiv pipeline in ray-curator consists of four stages:
+
+1. URL Generation: Lists available ArXiv source tar files from the S3 bucket
+2. Download: Downloads `.tar` archives via s5cmd (requester-pays)
+3. Iteration: Extracts LaTeX projects and yields per-paper records
+4. Extraction: Cleans LaTeX and produces plain text
+
+Internals (implemented):
+
+- URL generation: `ray_curator/stages/download/text/arxiv/url_generation.py`
+- Download: `ray_curator/stages/download/text/arxiv/download.py`
+- Iterator: `ray_curator/stages/download/text/arxiv/iterator.py`
+- Extractor: `ray_curator/stages/download/text/arxiv/extract.py`
+- Composite stage: `ray_curator/stages/download/text/arxiv/stage.py`
+
+## Before You Start
+
+You must have s5cmd installed and AWS credentials configured for requester-pays.
+
+- Install s5cmd: see `https://github.com/peak/s5cmd`
+- Configure AWS credentials in your environment (or `~/.aws/credentials`) with access to requester-pays buckets
+
+```{admonition} S3 Requester Pays
+:class: tip
+
+The ArXiv `s3://arxiv/src/` bucket is requester-pays. All listing and copy operations set requester-pays via s5cmd.
+```
+
+---
+
+## Usage
+
+Create and run an ArXiv processing pipeline and write outputs to JSONL:
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.backends.experimental.ray_data import RayDataExecutor
+from ray_curator.stages.download.text.arxiv import ArxivDownloadExtractStage
+from ray_curator.stages.io.writer import JsonlWriter
+from ray_curator.tasks import EmptyTask
+
+def main():
+    pipeline = Pipeline(
+        name="arxiv_pipeline",
+        description="Download and process ArXiv LaTeX sources"
+    )
+
+    # Add ArXiv stage
+    arxiv_stage = ArxivDownloadExtractStage(
+        download_dir="./arxiv_downloads",
+        url_limit=5,        # optional: number of tar files to process
+        record_limit=1000,  # optional: max papers per tar
+        add_filename_column=True,
+        verbose=True,
+    )
+    pipeline.add_stage(arxiv_stage)
+
+    # Add writer stage
+    writer = JsonlWriter(output_dir="./arxiv_output")
+    pipeline.add_stage(writer)
+
+    # Execute
+    executor = RayDataExecutor()
+    results = pipeline.run(executor, initial_tasks=[EmptyTask])
+    print(f"Completed with {len(results) if results else 0} output files")
+
+if __name__ == "__main__":
+    main()
+```
+
+### Parameters
+
+```{list-table} ArxivDownloadExtractStage Parameters
+:header-rows: 1
+:widths: 25 20 35 20
+
+* - Parameter
+  - Type
+  - Description
+  - Default
+* - `download_dir`
+  - str
+  - Directory to store downloaded `.tar` files
+  - "./arxiv_downloads"
+* - `url_limit`
+  - int | None
+  - Maximum number of ArXiv tar files to download (useful for testing)
+  - None
+* - `record_limit`
+  - int | None
+  - Maximum number of papers to extract per tar file
+  - None
+* - `add_filename_column`
+  - bool | str
+  - Whether to add a source filename column to output; if str, use it as the column name
+  - True (column name defaults to `file_name`)
+* - `log_frequency`
+  - int
+  - How often to log progress while iterating papers
+  - 1000
+* - `verbose`
+  - bool
+  - Enable verbose logging during download
+  - False
+```
+
+```{note}
+URL generation and download use s5cmd with requester-pays to list and copy from `s3://arxiv/src/`.
+```
+
+## Output Format
+
+The extractor returns per-paper text; the filename column is optionally added by the pipeline:
+
+```json
+{
+  "text": "Main body text extracted from LaTeX after cleaning...",
+  "file_name": "arXiv-2401.01234.tar"  
+}
+```
+
+```{list-table} Output Fields
+:header-rows: 1
+:widths: 20 80
+
+* - Field
+  - Description
+* - `text`
+  - Extracted and cleaned paper text (LaTeX macros inlined where supported, comments and references removed)
+* - `file_name`
+  - Optional. Name of the source tar file (enabled by `add_filename_column`)
+```
+
+```{admonition} Intermediate Fields
+:class: note
+
+During iteration the pipeline yields `id` (ArXiv identifier), `source_id` (tar basename), and `content` (list of LaTeX files). The final extractor stage emits only `text` plus the optional filename column.
+```
+
+## Advanced Notes
+
+- The pipeline validates paths and extracts tar files with path traversal protection.
+- The iterator and extractor adapt RedPajama preprocessing with safety and robustness improvements.
+- Macro expansion handles non-argument macros; macros with arguments are not expanded.
+
+See also: {ref}`Common Crawl <text-load-data-common-crawl>`, {ref}`Wikipedia <text-load-data-wikipedia>`

--- a/docs/curate-text/load-data/common-crawl.md
+++ b/docs/curate-text/load-data/common-crawl.md
@@ -1,0 +1,326 @@
+---
+description: "Download and extract text from Common Crawl web archives using ray-curator's pipeline framework"
+categories: ["how-to-guides"]
+tags: ["common-crawl", "web-data", "warc", "language-detection", "distributed", "html-extraction", "pipeline"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "intermediate"
+content_type: "how-to"
+modality: "text-only"
+---
+
+(text-load-data-common-crawl)=
+
+# Common Crawl
+
+Download and extract text from Common Crawl snapshots using ray-curator's pipeline framework.
+
+Common Crawl provides petabytes of web data collected over years of web crawling. The data uses a compressed web archive format (`.warc.gz`), which requires processing to extract useful text for language model training.
+
+## How it Works
+
+Ray-curator's Common Crawl processing pipeline consists of four sequential stages:
+
+1. **URL Generation**: Generates WARC file URLs from Common Crawl's index for the specified snapshot range
+2. **Download**: Downloads the compressed WARC files from Common Crawl's servers (optionally using S3 for faster downloads)
+3. **Iteration**: Extracts individual records from WARC files and decodes HTML content
+4. **Extraction**: Performs language detection and extracts clean text using configurable HTML extraction algorithms
+
+The pipeline outputs structured data that you can write to JSONL or Parquet files for further processing.
+
+---
+
+## Usage
+
+Here's how to create and run a Common Crawl processing pipeline:
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.backends.experimental.ray_data import RayDataExecutor
+from ray_curator.stages.download.text.common_crawl import CommonCrawlDownloadExtractStage
+from ray_curator.stages.io.writer import JsonlWriter
+from ray_curator.tasks import EmptyTask
+
+def main():
+    # Create pipeline
+    pipeline = Pipeline(
+        name="common_crawl_pipeline",
+        description="Download and process Common Crawl data"
+    )
+    
+    # Add Common Crawl processing stage
+    cc_stage = CommonCrawlDownloadExtractStage(
+        start_snapshot="2020-50",  # YYYY-WW format for CC-MAIN
+        end_snapshot="2020-50",
+        download_dir="./cc_downloads",
+        crawl_type="main",  # or "news"
+        use_aws_to_download=True,  # Faster S3 downloads (requires s5cmd)
+        url_limit=10,  # Limit number of WARC files for testing
+        record_limit=1000,  # Limit records per WARC file
+    )
+    pipeline.add_stage(cc_stage)
+    
+    # Add output writer stage
+    writer = JsonlWriter(output_dir="./cc_output")
+    pipeline.add_stage(writer)
+    
+    # Create executor and run pipeline
+    executor = RayDataExecutor()
+    results = pipeline.run(executor, initial_tasks=[EmptyTask])
+    
+    print(f"Pipeline completed. Results: {len(results) if results else 0} output files")
+
+if __name__ == "__main__":
+    main()
+```
+
+### Writing to Parquet
+
+To write Parquet instead of JSONL, use `ParquetWriter`:
+
+```python
+from ray_curator.stages.io.writer import ParquetWriter
+
+# Replace the JSONL writer with ParquetWriter
+writer = ParquetWriter(output_dir="./cc_output_parquet")
+pipeline.add_stage(writer)
+```
+
+### Parameters
+
+```{list-table} CommonCrawlDownloadExtractStage Parameters
+:header-rows: 1
+:widths: 25 20 35 20
+
+* - Parameter
+  - Type
+  - Description
+  - Default
+* - `start_snapshot`
+  - str
+  - First snapshot to include (format: "YYYY-WW" for main, "YYYY-MM" for news)
+  - Required
+* - `end_snapshot`
+  - str
+  - Last snapshot to include (same format as start_snapshot)
+  - Required
+* - `download_dir`
+  - str
+  - Directory to store downloaded WARC files
+  - Required
+* - `crawl_type`
+  - Literal["main", "news"]
+  - Whether to use CC-MAIN or CC-NEWS dataset
+  - "main"
+* - `html_extraction`
+  - HTMLExtractorAlgorithm | str | None
+  - Text extraction algorithm to use
+  - JusTextExtractor()
+* - `html_extraction_kwargs`
+  - dict | None
+  - Additional arguments for the HTML extractor
+  - None
+* - `stop_lists`
+  - dict[str, frozenset[str]] | None
+  - Language-specific stop words for text quality assessment
+  - None
+* - `use_aws_to_download`
+  - bool
+  - Use S3 downloads via s5cmd instead of HTTPS (requires s5cmd installation)
+  - False
+* - `verbose`
+  - bool
+  - Enable verbose logging for download operations
+  - False
+* - `url_limit`
+  - int | None
+  - Maximum number of WARC files to download (useful for testing)
+  - None
+* - `record_limit`
+  - int | None
+  - Maximum number of records to extract per WARC file
+  - None
+* - `add_filename_column`
+  - bool | str
+  - Whether to add source filename column to output; if str, uses it as the column name (default name: "file_name")
+  - True
+```
+
+```{admonition} Snapshot Availability
+:class: note
+
+Not every year and week has a snapshot. Ensure your range includes at least one valid Common Crawl snapshot. See [the official site](https://data.commoncrawl.org/) for a list of valid snapshots.
+```
+
+## Output Format
+
+The pipeline processes Common Crawl data through several stages, ultimately producing structured documents. The extracted text includes the following fields:
+
+```json
+{
+  "url": "http://example.com/page.html",
+  "warc_id": "a515a7b6-b6ec-4bed-998b-8be2f86f8eac", 
+  "source_id": "CC-MAIN-20201123153826-20201123183826-00000.warc.gz",
+  "language": "ENGLISH",
+  "text": "Extracted web page content..."
+}
+```
+
+```{list-table} Output Fields
+:header-rows: 1
+:widths: 20 80
+
+* - Field
+  - Description
+* - `url`
+  - Original URL of the web page
+* - `warc_id`
+  - Unique identifier for the WARC record
+* - `source_id`
+  - Name of the source WARC file
+* - `language`
+  - Detected language of the content (e.g., "ENGLISH", "SPANISH")
+* - `text`
+  - Extracted and cleaned text content
+```
+
+If you enable `add_filename_column`, the output includes an extra field `file_name` (or your custom column name).
+
+## Customization Options
+
+### HTML Text Extraction Algorithms
+
+Ray-curator supports several HTML text extraction algorithms, each with different strengths:
+
+```{list-table} Available HTML Extractors
+:header-rows: 1
+:widths: 25 25 50
+
+* - Extractor
+  - Library
+  - Best For
+* - `JusTextExtractor`
+  - [jusText](https://github.com/miso-belica/jusText)
+  - General web content, good boilerplate removal
+* - `ResiliparseExtractor`
+  - [Resiliparse](https://github.com/chatnoir-eu/chatnoir-resiliparse)
+  - High-performance extraction, research applications
+* - `TrafilaturaExtractor`
+  - [Trafilatura](https://trafilatura.readthedocs.io/)
+  - News articles, blog posts, high-quality text
+```
+
+#### Configuring HTML Extractors
+
+```python
+from ray_curator.stages.download.text.html_extractors import (
+    ResiliparseExtractor,
+    TrafilaturaExtractor
+)
+
+# Use Resiliparse for extraction
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-50",
+    end_snapshot="2020-50",
+    download_dir="./downloads",
+    html_extraction=ResiliparseExtractor(
+        required_stopword_density=0.25,
+        main_content=True
+    )
+)
+
+# Or use Trafilatura with custom parameters
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-50", 
+    end_snapshot="2020-50",
+    download_dir="./downloads",
+    html_extraction=TrafilaturaExtractor(
+        min_extracted_size=200,
+        max_repetitions=3
+    )
+)
+```
+
+```{note}
+When `html_extraction` is passed as an extractor instance (for example, `JusTextExtractor()`), the `html_extraction_kwargs` parameter is ignored. To customize the extractor in this case, pass keyword arguments directly to the extractor constructor.
+```
+
+### Language Processing
+
+You can customize language detection and extraction by providing stop words for different languages:
+
+```python
+# Define custom stop words for specific languages
+stop_lists = {
+    "ENGLISH": frozenset(["the", "and", "is", "in", "for", "where", "when", "to", "at"]),
+    "SPANISH": frozenset(["el", "la", "de", "que", "y", "en", "un", "es", "se", "no"])
+}
+
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-50",
+    end_snapshot="2020-50", 
+    download_dir="./downloads",
+    stop_lists=stop_lists
+)
+```
+
+```{note}
+If no custom stop lists are provided, ray-curator uses jusText's default stop lists with additional support for Thai, Chinese, and Japanese languages.
+```
+
+## Advanced Usage
+
+### Using Different Executors
+
+Ray-curator supports several execution backends:
+
+```python
+# Ray Data executor (recommended for most use cases)
+from ray_curator.backends.experimental.ray_data import RayDataExecutor
+executor = RayDataExecutor()
+
+# Xenna executor (for specialized workflows)
+from ray_curator.backends.xenna import XennaExecutor
+executor = XennaExecutor()
+```
+
+### Processing CC-NEWS Data
+
+For Common Crawl News data, use the `news` crawl type with month-based snapshots:
+
+```python
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-08",  # YYYY-MM format for CC-NEWS
+    end_snapshot="2020-10",
+    download_dir="./news_downloads",
+    crawl_type="news"  # Use CC-NEWS instead of CC-MAIN
+)
+```
+
+### Large-Scale Processing
+
+For production workloads, consider these optimizations:
+
+```python
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-50",
+    end_snapshot="2020-52", 
+    download_dir="/fast_storage/cc_downloads",
+    use_aws_to_download=True,  # Faster S3 downloads
+    verbose=False,  # Reduce logging overhead
+    # Remove limits for full processing
+    # url_limit=None,
+    # record_limit=None
+)
+```
+
+::::{admonition} S3 Download Requirements
+:class: tip
+
+To use `use_aws_to_download=True`, you must install [s5cmd](https://github.com/peak/s5cmd):
+
+```bash
+# Install s5cmd for faster S3 downloads
+go install github.com/peak/s5cmd/v2@latest
+```
+
+::::

--- a/docs/curate-text/load-data/custom.md
+++ b/docs/curate-text/load-data/custom.md
@@ -1,0 +1,452 @@
+---
+description: "Create custom data loading pipelines using Ray Curator's stage-based architecture with composable components"
+categories: ["how-to-guides"]
+tags: ["custom-data", "stages", "pipelines", "data-loading", "ray-curator"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "advanced"
+content_type: "how-to"
+modality: "text-only"
+---
+
+(text-load-data-custom)=
+
+# Custom Data Loading
+
+Create custom data loading pipelines using Ray Curator's modular stage-based architecture. This guide shows how to build custom components that integrate seamlessly with Ray Curator's distributed processing framework.
+
+## How It Works
+
+Ray Curator uses a **4-step pipeline pattern** for custom data loading:
+
+1. **URL Generation**: Generate URLs from configuration or input parameters
+2. **Download**: Download files from URLs to local storage  
+3. **Iteration**: Extract raw records from downloaded files
+4. **Extraction** (Optional): Transform raw records into final structured format
+
+Each step uses an abstract base class with corresponding processing stages that compose into pipelines.
+
+---
+
+## Architecture Overview
+
+### Core Components
+
+- **Tasks**: Data containers that flow through the pipeline (`DocumentBatch`, `FileGroupTask`)
+- **Stages**: Processing units that transform tasks (`ProcessingStage` subclasses)
+- **Pipelines**: Compositions of stages executed sequentially
+- **Executors**: Runtime backends that execute pipelines (Ray Data, Cosmos-Xenna)
+
+### Data Flow
+
+```text
+_EmptyTask → FileGroupTask → DocumentBatch
+     ↓             ↓              ↓
+URLGeneration → Download → Iterate → Extract
+```
+
+---
+
+## Implementation Guide
+
+### 1. Create Directory Structure
+
+```text
+your_data_source/
+├── __init__.py
+├── stage.py           # Main composite stage
+├── url_generation.py  # URL generation logic
+├── download.py        # Download implementation
+├── iterator.py        # File iteration logic
+└── extract.py         # Data extraction logic (optional)
+```
+
+### 2. Build Core Components
+
+#### URL Generator (`url_generation.py`)
+
+```python
+from ray_curator.stages.download.text import URLGenerator
+
+class CustomURLGenerator(URLGenerator):
+    def __init__(self, config_param: str):
+        self.config_param = config_param
+    
+    def generate_urls(self) -> list[str]:
+        """Generate list of URLs to download."""
+        # Your URL generation logic here
+        return [
+            "https://example.com/dataset1.zip",
+            "https://example.com/dataset2.zip",
+        ]
+```
+
+#### Document Download Handler (`download.py`)
+
+```python
+import requests
+from ray_curator.stages.download.text import DocumentDownloader
+
+class CustomDownloader(DocumentDownloader):
+    def __init__(self, download_dir: str, verbose: bool = False):
+        super().__init__(download_dir, verbose)
+    
+    def _get_output_filename(self, url: str) -> str:
+        """Extract filename from URL."""
+        return url.split('/')[-1]
+    
+    def _download_to_path(self, url: str, path: str) -> tuple[bool, str | None]:
+        """Download file from URL to local path."""
+        try:
+            response = requests.get(url, stream=True, timeout=30)
+            response.raise_for_status()
+            
+            with open(path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            
+            return True, None
+        except Exception as e:
+            return False, str(e)
+```
+
+#### Document Iterator (`iterator.py`)
+
+```python
+import json
+from collections.abc import Iterator
+from typing import Any
+from ray_curator.stages.download.text import DocumentIterator
+
+class CustomIterator(DocumentIterator):
+    def __init__(self, record_format: str = "jsonl"):
+        self.record_format = record_format
+    
+    def iterate(self, file_path: str) -> Iterator[dict[str, Any]]:
+        """Iterate over records in a file."""
+        if self.record_format == "jsonl":
+            with open(file_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if line.strip():
+                        yield json.loads(line)
+        # Add other format handlers as needed
+    
+    def output_columns(self) -> list[str]:
+        """Define output columns."""
+        return ["content", "metadata", "id"]
+```
+
+#### Document Extractor (`extract.py`)
+
+```python
+from typing import Any
+from ray_curator.stages.download.text import DocumentExtractor
+
+class CustomExtractor(DocumentExtractor):
+    def extract(self, record: dict[str, str]) -> dict[str, Any] | None:
+        """Transform raw record to final format."""
+        # Skip invalid records
+        if not record.get("content"):
+            return None
+        
+        # Extract and clean text
+        cleaned_text = self._clean_text(record["content"])
+        
+        # Generate unique ID if not present
+        doc_id = record.get("id", self._generate_id(cleaned_text))
+        
+        return {
+            "text": cleaned_text,
+            "id": doc_id,
+            "source": record.get("metadata", {}).get("source", "unknown")
+        }
+    
+    def input_columns(self) -> list[str]:
+        return ["content", "metadata", "id"]
+    
+    def output_columns(self) -> list[str]:
+        return ["text", "id", "source"]
+    
+    def _clean_text(self, text: str) -> str:
+        """Clean and normalize text."""
+        # Your text cleaning logic here
+        return text.strip()
+    
+    def _generate_id(self, text: str) -> str:
+        """Generate unique ID for text."""
+        import hashlib
+        return hashlib.md5(text.encode()).hexdigest()[:16]
+```
+
+### 3. Create Composite Stage (`stage.py`)
+
+```python
+from ray_curator.stages.download.text import DocumentDownloadExtractStage
+from .url_generation import CustomURLGenerator
+from .download import CustomDownloader
+from .iterator import CustomIterator
+from .extract import CustomExtractor
+
+class CustomDataStage(DocumentDownloadExtractStage):
+    """Custom data loading stage combining all components."""
+    
+    def __init__(
+        self,
+        config_param: str,
+        download_dir: str,
+        record_format: str = "jsonl",
+        url_limit: int | None = None,
+        record_limit: int | None = None,
+        **kwargs
+    ):
+        super().__init__(
+            url_generator=CustomURLGenerator(config_param),
+            downloader=CustomDownloader(download_dir),
+            iterator=CustomIterator(record_format),
+            extractor=CustomExtractor(),  # Optional - remove if not needed
+            url_limit=url_limit,
+            record_limit=record_limit,
+            **kwargs
+        )
+```
+
+---
+
+## Usage Examples
+
+### Basic Pipeline
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.backends.xenna import XennaExecutor
+from your_data_source.stage import CustomDataStage
+
+def main():
+    # Create custom data loading stage
+    data_stage = CustomDataStage(
+        config_param="production",
+        download_dir="/tmp/downloads",
+        record_limit=1000  # Limit for testing
+    )
+    
+    # Create pipeline
+    pipeline = Pipeline(
+        name="custom_data_pipeline",
+        description="Load and process custom dataset"
+    )
+    pipeline.add_stage(data_stage)
+    
+    # Create executor
+    executor = XennaExecutor()
+    
+    # Run pipeline
+    print("Starting pipeline...")
+    results = pipeline.run(executor)
+    
+    # Process results
+    if results:
+        for task in results:
+            print(f"Processed {task.num_items} documents")
+            # Access data as pandas DataFrame
+            df = task.to_pandas()
+            print(df.head())
+
+if __name__ == "__main__":
+    main()
+```
+
+### Adding Processing Stages
+
+```python
+from ray_curator.stages.modules import ScoreFilter
+from ray_curator.stages.filters import WordCountFilter
+from ray_curator.stages.io.writer import JsonlWriter
+
+def create_full_pipeline():
+    pipeline = Pipeline(name="full_processing")
+    
+    # Data loading
+    pipeline.add_stage(CustomDataStage(
+        config_param="production",
+        download_dir="/tmp/downloads"
+    ))
+    
+    # Text filtering
+    pipeline.add_stage(ScoreFilter(
+        filter_obj=WordCountFilter(min_words=10, max_words=1000),
+        text_field="text"
+    ))
+    
+    # Output
+    pipeline.add_stage(JsonlWriter(output_dir="/output/processed"))
+    
+    return pipeline
+```
+
+### Configuration-Based Setup
+
+```python
+from ray_curator.config import BaseConfig
+
+class CustomDataConfig(BaseConfig):
+    config_param: str = "development"
+    download_dir: str = "/tmp/downloads"
+    record_format: str = "jsonl"
+    url_limit: int | None = None
+    record_limit: int | None = None
+
+def create_pipeline_from_config(config_path: str):
+    config = CustomDataConfig.from_yaml(config_path)
+    
+    stage = CustomDataStage(
+        config_param=config.config_param,
+        download_dir=config.download_dir,
+        record_format=config.record_format,
+        url_limit=config.url_limit,
+        record_limit=config.record_limit
+    )
+    
+    pipeline = Pipeline("configured_pipeline")
+    pipeline.add_stage(stage)
+    
+    return pipeline
+```
+
+---
+
+## Parameters Reference
+
+```{list-table} Custom Data Loading Parameters
+:header-rows: 1
+:widths: 20 20 40 20
+
+* - Parameter
+  - Type
+  - Description
+  - Default
+* - `url_generator`
+  - URLGenerator
+  - Custom URL generation implementation
+  - Required
+* - `downloader`
+  - DocumentDownloader
+  - Custom download implementation
+  - Required
+* - `iterator`
+  - DocumentIterator
+  - Custom file iteration implementation
+  - Required
+* - `extractor`
+  - DocumentExtractor | None
+  - Optional extraction/transformation step
+  - None
+* - `url_limit`
+  - int | None
+  - Maximum number of URLs to process
+  - None
+* - `record_limit`
+  - int | None
+  - Maximum records per file
+  - None
+* - `add_filename_column`
+  - bool | str
+  - Add filename column to output; if str, uses it as the column name (default name: "file_name")
+  - True
+```
+
+---
+
+## Output Format
+
+Processed data flows through the pipeline as `DocumentBatch` tasks containing pandas DataFrames or PyArrow Tables:
+
+### Example Output Schema
+
+```python
+{
+    "text": "This is the processed document text",
+    "id": "unique-document-id",
+    "source": "example.com",
+    "file_name": "dataset1.jsonl"  # If add_filename_column=True (default column name)
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Error Handling
+
+```python
+def _download_to_path(self, url: str, path: str) -> tuple[bool, str | None]:
+    try:
+        # Download logic
+        return True, None
+    except requests.RequestException as e:
+        self.logger.error(f"Network error downloading {url}: {e}")
+        return False, str(e)
+    except Exception as e:
+        self.logger.error(f"Unexpected error: {e}")
+        return False, str(e)
+```
+
+### 2. Resource Management
+
+```python
+from ray_curator.stages.resources import Resources
+
+class CustomDataStage(DocumentDownloadExtractStage):
+    # Override resources for download-heavy stages
+    _resources = Resources(cpus=2.0)  # More CPU for downloads
+```
+
+### 3. Progress Tracking
+
+```python
+def iterate(self, file_path: str) -> Iterator[dict[str, Any]]:
+    with open(file_path, 'r') as f:
+        for i, line in enumerate(f):
+            if i % 1000 == 0:
+                self.logger.info(f"Processed {i} records from {file_path}")
+            yield json.loads(line)
+```
+
+### 4. Validation
+
+```python
+def extract(self, record: dict[str, str]) -> dict[str, Any] | None:
+    # Validate required fields
+    if not all(field in record for field in ["content", "id"]):
+        self.logger.warning(f"Skipping record missing required fields")
+        return None
+    
+    # Validate content quality
+    if len(record["content"]) < 10:
+        return None
+    
+    return self._process_record(record)
+```
+
+### 5. Memory Efficiency
+
+- Process files in streaming fashion
+- Use generators for large datasets
+- Apply proper cleanup in download handlers
+- Consider batch sizes for extraction steps
+
+### 6. Testing
+
+```python
+def test_custom_extractor():
+    extractor = CustomExtractor()
+    
+    test_record = {
+        "content": "Sample text content",
+        "id": "test-123",
+        "metadata": {"source": "test"}
+    }
+    
+    result = extractor.extract(test_record)
+    assert result is not None
+    assert "text" in result
+    assert result["id"] == "test-123"
+```

--- a/docs/curate-text/load-data/index.md
+++ b/docs/curate-text/load-data/index.md
@@ -1,0 +1,187 @@
+---
+description: "Load text data from various sources including Common Crawl, Wikipedia, and custom datasets using NeMo Curator's ray-curator framework"
+categories: ["workflows"]
+tags: ["data-loading", "common-crawl", "wikipedia", "custom-data", "distributed", "ray"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "intermediate"
+content_type: "workflow"
+modality: "text-only"
+---
+
+(text-load-data)=
+
+# Text Data Loading
+
+Load text data from a variety of data sources using NeMo Curator's ray-curator framework.
+
+NeMo Curator provides a task-centric pipeline framework for downloading and processing large-scale public text datasets. The framework uses Ray as the distributed backend and converts raw data formats like Common Crawl's `.warc.gz` to processing-friendly formats like `.jsonl`.
+
+## How it Works
+
+Ray-curator's data loading framework uses a **4-step pipeline pattern** where data flows through stages as tasks:
+
+1. **URL Generation**: Generate URLs from configuration (`URLGenerationStage`)
+2. **Download**: Retrieve files from URLs to local storage (`DocumentDownloadStage`)
+3. **Iteration**: Parse downloaded files to extract raw records (`DocumentIterateStage`)
+4. **Extraction**: Extract and clean structured content from raw records (`DocumentExtractStage`)
+
+Each step uses a `ProcessingStage` that transforms tasks. The pipeline flow is:
+
+```text
+_EmptyTask → FileGroupTask(URLs) → FileGroupTask(Files) → DocumentBatch → DocumentBatch
+```
+
+Data sources provide composite stages that combine these steps into complete download-extract pipelines, producing `DocumentBatch` tasks for further processing.
+
+::::{tab-set}
+
+:::{tab-item} Python
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.backends.xenna import XennaExecutor
+from ray_curator.stages.download.text.common_crawl import CommonCrawlDownloadExtractStage
+from ray_curator.stages.io.writer import JsonlWriter
+from ray_curator.tasks import EmptyTask
+
+# Create a pipeline for downloading Common Crawl data
+pipeline = Pipeline(
+    name="common_crawl_download",
+    description="Download and process Common Crawl web archives"
+)
+
+# Add data loading stage
+cc_stage = CommonCrawlDownloadExtractStage(
+    start_snapshot="2020-50",
+    end_snapshot="2020-50", 
+    download_dir="/tmp/cc_downloads",
+    crawl_type="main",
+    url_limit=10  # Limit for testing
+)
+pipeline.add_stage(cc_stage)
+
+# Add writer stage to save as JSONL
+writer = JsonlWriter(output_dir="/output/folder")
+pipeline.add_stage(writer)
+
+# Build and execute pipeline
+pipeline.build()
+executor = XennaExecutor()
+
+# Start with an empty task to trigger URL generation
+results = pipeline.run(executor, initial_tasks=[EmptyTask])
+```
+
+:::
+
+:::{tab-item} Reading Custom Data
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.stages.io.reader import JsonlReader
+from ray_curator.stages.modules import ScoreFilter
+from ray_curator.stages.filters import WordCountFilter
+
+# Create pipeline for processing existing JSONL files
+pipeline = Pipeline(name="custom_data_processing")
+
+# Read JSONL files
+reader = JsonlReader(
+    file_paths="/path/to/data/*.jsonl",
+    files_per_partition=4,
+    columns=["text", "url"]  # Only read specific columns
+)
+pipeline.add_stage(reader)
+
+# Add filtering stage
+word_filter = ScoreFilter(
+    filter_obj=WordCountFilter(min_words=50, max_words=1000),
+    text_field="text"
+)
+pipeline.add_stage(word_filter)
+
+# Execute pipeline
+executor = XennaExecutor()
+results = pipeline.run(executor)
+```
+
+:::
+
+::::
+
+---
+
+## Data Sources & File Formats
+
+Load data from public datasets and custom data sources using ray-curator stages.
+
+::::{grid} 1 1 1 2
+:gutter: 1 1 1 2
+
+:::{grid-item-card} {octicon}`download;1.5em;sd-mr-1` Common Crawl
+:link: text-load-data-common-crawl
+:link-type: ref
+Download and process web archive data from Common Crawl
++++
+{bdg-secondary}`web-data`
+{bdg-secondary}`warc`
+{bdg-secondary}`html-extraction`
+:::
+
+:::{grid-item-card} {octicon}`download;1.5em;sd-mr-1` Wikipedia
+:link: text-load-data-wikipedia  
+:link-type: ref
+Download and extract Wikipedia articles from Wikipedia dumps
++++
+{bdg-secondary}`articles`
+{bdg-secondary}`multilingual`
+{bdg-secondary}`xml-dumps`
+:::
+
+:::{grid-item-card} {octicon}`download;1.5em;sd-mr-1` Custom Data
+:link: text-load-data-custom
+:link-type: ref
+Read and process your own text datasets in standard formats
++++
+{bdg-secondary}`jsonl`
+{bdg-secondary}`parquet`
+{bdg-secondary}`file-partitioning`
+:::
+
+::::
+
+## Key Components
+
+### Tasks
+
+Ray-curator operates on **Tasks** - batches of data that flow through the pipeline:
+
+- **`_EmptyTask`**: Starting point for pipelines that generate data
+- **`FileGroupTask`**: Contains file paths (URLs or local files)  
+- **`DocumentBatch`**: Contains text documents as pandas DataFrame or PyArrow Table
+
+### Stages
+
+**ProcessingStages** transform tasks through the pipeline:
+
+- **Composite Stages**: High-level stages like `CommonCrawlDownloadExtractStage` that decompose into several steps
+- **Atomic Stages**: Individual processing steps like `DocumentDownloadStage`, `JsonlReaderStage`
+- **I/O Stages**: File readers (`JsonlReader`) and writers (`JsonlWriter`, `ParquetWriter`)
+
+### Executors
+
+**Executors** run pipelines on different backends:
+
+- **`XennaExecutor`**: Production-ready executor using Cosmos framework
+- **`RayDataExecutor`**: Experimental executor using Ray Data
+
+```{toctree}
+:maxdepth: 4
+:titlesonly:
+:hidden:
+
+arxiv
+common-crawl
+wikipedia
+Custom Data <custom.md>
+```

--- a/docs/curate-text/load-data/wikipedia.md
+++ b/docs/curate-text/load-data/wikipedia.md
@@ -1,0 +1,186 @@
+---
+description: "Download and extract text from Wikipedia dumps using ray-curator's pipeline-based processing"
+categories: ["how-to-guides"]
+tags: ["wikipedia", "dumps", "multilingual", "articles", "data-loading", "ray-curator"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "intermediate"
+content_type: "how-to"
+modality: "text-only"
+---
+
+(text-load-data-wikipedia)=
+
+# Wikipedia
+
+Download and extract text from [Wikipedia Dumps](https://dumps.wikimedia.org/backup-index.html) using ray-curator's pipeline-based processing system.
+
+Wikipedia releases compressed dumps of all its content in XML format twice per month. ray-curator provides a complete pipeline to automatically download, parse, and extract clean text from these dumps.
+
+## How it Works
+
+The Wikipedia pipeline in ray-curator consists of four stages:
+
+1. **URL Generation**: Automatically discovers Wikipedia dump URLs for the specified language and date
+2. **Download**: Downloads compressed .bz2 dump files using `wget`
+3. **Iteration**: Parses XML content and extracts individual articles
+4. **Extraction**: Cleans Wikipedia markup and converts to plain text
+
+## Before You Start
+
+ray-curator uses `wget` to download Wikipedia dumps. You must have `wget` installed on your system:
+
+- **On macOS**:  `brew install wget`
+- **On Ubuntu/Debian**: `sudo apt-get install wget`
+- **On CentOS/RHEL**:  `sudo yum install wget`
+
+---
+
+## Usage
+
+Here's how to download and extract Wikipedia data using ray-curator:
+
+```python
+from ray_curator.pipeline import Pipeline
+from ray_curator.backends.xenna import XennaExecutor
+from ray_curator.stages.download.text.wikipedia import WikipediaDownloadExtractStage
+from ray_curator.stages.io.writer import JsonlWriter
+from ray_curator.tasks import EmptyTask
+
+# Create the Wikipedia processing stage
+wikipedia_stage = WikipediaDownloadExtractStage(
+    language="en",
+    download_dir="./wikipedia_downloads",
+    dump_date="20240401",  # Optional: specific dump date (YYYYMMDD format)
+    url_limit=5,           # Optional: limit number of dump files (useful for testing)
+    record_limit=1000,     # Optional: limit articles per dump file
+    verbose=True
+)
+
+# Create writer stage to save results
+writer_stage = JsonlWriter(
+    output_dir="./wikipedia_output"
+)
+
+# Create and configure pipeline
+pipeline = Pipeline(
+    name="wikipedia_pipeline",
+    description="Download and process Wikipedia dumps"
+)
+pipeline.add_stage(wikipedia_stage)
+pipeline.add_stage(writer_stage)
+
+# Create executor and run pipeline
+executor = XennaExecutor()
+
+# Start with an empty task to trigger URL generation
+initial_tasks = [EmptyTask]
+
+# Execute the pipeline
+results = pipeline.run(executor, initial_tasks=initial_tasks)
+print(f"Pipeline completed with {len(results) if results else 0} output files")
+```
+
+### Multi-Language Processing
+
+You can process several languages by creating separate pipelines:
+
+```python
+languages = ["en", "es", "fr", "de"]
+
+for lang in languages:
+    # Create language-specific pipeline
+    wikipedia_stage = WikipediaDownloadExtractStage(
+        language=lang,
+        download_dir=f"./downloads/{lang}",
+        dump_date="20240401"
+    )
+    
+    writer_stage = JsonlWriter(
+        output_dir=f"./output/{lang}"
+    )
+    
+    pipeline = Pipeline(name=f"wikipedia_{lang}")
+    pipeline.add_stage(wikipedia_stage)
+    pipeline.add_stage(writer_stage)
+    
+    # Execute
+    results = pipeline.run(executor, initial_tasks=[EmptyTask])
+```
+
+### Parameters
+
+```{list-table}
+:header-rows: 1
+:widths: 20 20 20 40
+
+* - Parameter
+  - Type
+  - Default
+  - Description
+* - `language`
+  - str
+  - "en"
+  - Language code for Wikipedia dump (e.g., "en", "es", "fr")
+* - `download_dir`
+  - str
+  - "./wikipedia_downloads"
+  - Directory to store downloaded .bz2 files
+* - `dump_date`
+  - Optional[str]
+  - None
+  - Specific dump date in "YYYYMMDD" format (e.g., "20240401"). If None, uses latest available dump
+* - `wikidumps_index_prefix`
+  - str
+  - "https://dumps.wikimedia.org"
+  - Base URL for Wikipedia dumps index
+* - `verbose`
+  - bool
+  - False
+  - Enable verbose logging during download
+* - `url_limit`
+  - Optional[int]
+  - None
+  - Maximum number of dump URLs to process (useful for testing)
+* - `record_limit`
+  - Optional[int]
+  - None
+  - Maximum number of articles to extract per dump file
+* - `add_filename_column`
+  - bool | str
+  - True
+  - Whether to add source filename column to output; if str, uses it as the column name (default name: "file_name")
+* - `log_frequency`
+  - int
+  - 1000
+  - How often to log progress during article processing
+```
+
+::::{note}
+Wikipedia creates new dumps twice per month (around the 1st and 20th). You can find available dump dates at <https://dumps.wikimedia.org/enwiki/>.
+::::
+
+## Output Format
+
+The processed Wikipedia articles become JSONL files, with each line containing a JSON object with these fields:
+
+- `text`: The cleaned main text content of the article
+- `title`: The title of the Wikipedia article
+- `id`: Wikipedia's unique identifier for the article
+- `url`: The constructed Wikipedia URL for the article
+- `language`: The language code of the article
+- `source_id`: Identifier of the source dump file
+
+If you enable `add_filename_column`, the output includes an extra field `file_name` (or your custom column name).
+
+### Example Output Record
+
+```json
+{
+  "text": "Python is a high-level, general-purpose programming language...",
+  "title": "Python (programming language)",
+  "id": "23862",
+  "url": "https://en.wikipedia.org/wiki/Python_(programming_language)",
+  "language": "en",
+  "source_id": "enwiki-20240401-pages-articles-multistream1.xml"
+}
+```


### PR DESCRIPTION
This PR isolates only changes under `docs/curate-text/load-data/` from `llane/docs-updates-25.09` into a fresh branch as a single commit for focused review. No other files are included.